### PR TITLE
CDR-1378 Change docker build to use python:3.11.9-slim-bullseye

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Ignore everything
+*
+
+# Allow files and directories
+!/tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the desired base image
-FROM python:3.11.3
+FROM python:3.11.9-slim-bullseye
 
 # Set the working directory
 WORKDIR /integration-tests

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,7 +13,7 @@ RESTinstance == 1.1.0
 
 docker == 4.0.2
 deepdiff == 4.3.2
-psycopg2-binary == 2.8.6
+psycopg2-binary == 2.9.9
 python-benedict == 0.24.2
 
 pyjwt == 2.4.0


### PR DESCRIPTION
Change docker base image to python:3.11.9-slim-bullseye and also excluded everything from docker build except the `tests` directory.

This changes the image size:

from:
```
ehrbase/integration-tests -  latest    1.03GB
``` 

to
```
ehrbase/integration-tests - slim_bullseye   255MB
```

I have also replaced the deprecated `pg_config-binary` with a `psycopg2-binary`.