### PR TITLE
[CDR-1378] Move-scripts-from-ehrbase

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 
 # Allow files and directories
 !/tests
+!/scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ FROM python:3.11.9-slim-bullseye
 # Set the working directory
 WORKDIR /integration-tests
 
-# Copy the requirements.txt file to the working directory
-COPY tests/requirements.txt .
-
-# Install dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+# copy support scripts
+COPY --chmod=755 ./scripts/collectRebotResults.sh /bin/collectRebotResults
+COPY --chmod=755 ./scripts/runRobotTest.sh /bin/runRobotTest
 
 # Copy the rest of the project files to the working directory
-COPY . .
+COPY ./tests ./tests
+
+# Install dependencies
+RUN mv ./tests/requirements.txt ./requirements.txt && \
+    pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Please refer to https://docs.ehrbase.org/en/latest/03_development/02_testing/index.html
 
-## Running the tests
+## Running the tests locally
 
 This command will run all tests from `tests/robot` folder.
 DB and server have to be started prior to running the tests.
@@ -12,4 +12,20 @@ DB and server have to be started prior to running the tests.
 ```bash
 cd tests
 ./run_local_tests.sh
+```
+
+## Running the test using docker
+
+Execute a single test suite and store results in `./results`: 
+```bash
+docker run -ti -v ./results:/integration-tests/results ehrbase/integration-tests:build runRobotTest \
+  --serverBase http://ehrbase:8080 \
+  --name SANITY \
+  --path SANITY_TESTS \
+  --tags Sanity 
+```
+
+Collect results of multiple tests into a single report
+```bash
+docker run -ti -v ./results:/integration-tests/results -v ./report:/integration-tests/report ehrbase/integration-tests:build collectRebotResults
 ```

--- a/scripts/collectRebotResults.sh
+++ b/scripts/collectRebotResults.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#set -u
+
+base=$(pwd)
+dirResults="$base/results"
+dirReport="$base/report"
+
+
+############################################################
+# Ensures we have a clean report directory                 #
+############################################################
+
+mkdir -p ${dirReport}
+rm -Rf ${dirReport}/*
+
+
+############################################################
+# Run rebot                                                #
+############################################################
+
+echo "------------------------------------------------------"
+echo "Collecting Robot Test-Results:"
+echo "  - $(ls -m ${dirResults} | sed -e $'s/, /\\\n  - /g')"
+echo "------------------------------------------------------"
+
+# run rebot
+rebot \
+    --name EHRbase \
+    --outputdir ${dirReport} \
+    --log Final_Log.html \
+    --report Final_Report.html \
+    --output output.xml \
+    ${dirResults}/*/output.xml
+
+# allow to read/write the result for everyone
+chmod -R ugo+rw  ${dirReport}
+
+exit 0

--- a/scripts/runRobotTest.sh
+++ b/scripts/runRobotTest.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+set -u
+
+base=$(pwd)
+dirResults="$base/results"
+
+
+############################################################
+# Help                                                     #
+############################################################
+showHelp()
+{
+   # Display Help
+   echo "Run a given robot integration tests suite."
+   echo
+   echo "Syntax:  runRobotTests [h|-n|-p|-t|-s]"
+   echo
+   echo "Example: runRobotTests --name SANITY --path SANITY_TESTS --tags Sanity -t TEST"
+   echo
+   echo "options:"
+   echo "n|name         Name of the suite also used as result sub directory."
+   echo "p|path         Path of the suite to run."
+   echo "t|tags         Include tags."
+   echo "s|suite        SUT param defaults to 'TEST'."
+   echo "serverBase     Ehrbase server base, defaults to env var EHRBASE_BASE_URL or fallback to http://ehrbase:8080"
+   echo "serverNodeName Ehrbase server node name, defaults to env var SERVER_NODENAME or fallback to local.ehrbase.org"
+   echo
+}
+
+name=0
+path=0
+tags=0
+suite='TEST'
+serverBase=${EHRBASE_BASE_URL:-http://ehrbase:8080}
+serverNodeName=${SERVER_NODENAME:-local.ehrbase.org}
+POSITIONAL_ARGS=()
+
+############################################################
+# parse command line args                                  #
+############################################################
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      showHelp
+      exit
+      ;;
+    -n|--name)
+      name="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -p|--path)
+      path="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -t|--tags)
+      tags="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -s|--suite)
+      suite="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --serverBase)
+      serverBase="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --serverNodeName)
+      serverNodeName="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    *)
+      echo "Error: Invalid option [$1]"
+      exit -1;;
+  esac
+done
+
+
+############################################################
+# Checks given parameters                                  #
+############################################################
+
+if [ $name == 0 ]; then
+    echo "Option [name] not specified"
+    exit -1
+fi
+if [ $path == 0 ]; then
+    echo "Option [path] not specified"
+    exit -1
+fi
+if [ $path == 0 ]; then
+    echo "Option [path] not specified"
+    exit -1
+fi
+
+
+############################################################
+# Ensures we are in a clean result directory               #
+############################################################
+
+rm -Rf ${dirResults}/${name}
+
+
+############################################################
+# Run tests                                                #
+############################################################
+
+echo "---------------------------------------------------------------------------------------"
+echo "Running Robot Test-Suite [name: ${name}, path: ${path}, tags: ${tags}, suite: ${suite}]"
+echo "---------------------------------------------------------------------------------------"
+
+cd tests
+robot --include ${tags} \
+      --skip TODO \
+      --skip future \
+      --loglevel INFO \
+      -e ADMIN \
+      -e SECURITY \
+      --dotted \
+      --console quiet \
+      --skiponfailure not-ready -L TRACE \
+      --flattenkeywords for \
+      --flattenkeywords foritem \
+      --flattenkeywords name:_resources.* \
+      --flattenkeywords "name:composition_keywords.Load Json File With Composition" \
+      --flattenkeywords "name:template_opt1.4_keywords.upload OPT file" \
+      --removekeywords "name:JSONLibrary.Load Json From File" \
+      --removekeywords "name:Change Json KeyValue and Save Back To File" \
+      --removekeywords "name:JSONLibrary.Update Value To Json" \
+      --removekeywords "name:JSONLibrary.Convert JSON To String" \
+      --removekeywords "name:JSONLibrary.Get Value From Json" \
+      --report NONE \
+      --name ${name} \
+      --outputdir ${dirResults}/${name} \
+      -v SUT:${suite} \
+      -v nodocker \
+      -v NODENAME:${serverNodeName} \
+      -v BASEURL:${serverBase}/ehrbase/rest/openehr/v1 \
+      robot/${path}


### PR DESCRIPTION
Add Scripts to the test image, that can be used as a wrapper to run a test suite as well as collect the final test report.

This scripts can be easily used for the ehrbase integration tests as well as on any machine without installing python + test dependencies.

Usage: https://github.com/ehrbase/integration-tests/blob/feature/CDR-1378-move-scripts-from-ehrbase/README.md?plain=1#L17-L31